### PR TITLE
Widen tooltip background for SW rendering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -413,7 +413,7 @@ impl canvas::Program<ClockMessage> for Clock {
             let tooltip = canvas::Cache::default().draw(renderer, bounds.size(), |frame| {
                 let font_size = 16.0;
                 let padding = 4.0;
-                let text_width = 62.0; // Approximate width for "HH:MM AM" at 16px
+                let text_width = 92.0; // Width for "HH:MM AM" tooltip (wider for SW rendering)
                 let text_height = font_size;
 
                 // Position tooltip near cursor with offset


### PR DESCRIPTION
## Summary
- Increase tooltip background width by 30px (62 → 92)
- Fixes text clipping when using tiny-skia software rendering on Raspberry Pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted clock time tooltip width for improved visibility and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->