### PR TITLE
Close modal dialog on login failure instead of closing app

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -371,6 +371,7 @@ impl Clock {
                     }
                     Err(e) => {
                         eprintln!("Login failed: {}", e);
+                        self.menu_open = false; // Close modal on login failure
                         self.clock.clear();
                     }
                 }


### PR DESCRIPTION
## Summary
- When Google login times out or fails, close the modal dialog and return to the app
- Previously the error was only printed to stderr, leaving the modal open and confusing users
- Now users can continue using the app normally after a login failure/timeout

## Test plan
- [ ] Start the app and open the login modal
- [ ] Click login to open the Google authentication page
- [ ] Close the browser window without completing login
- [ ] Wait for the 2-minute timeout
- [ ] Verify the modal closes and the app continues running normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Login modal now closes automatically following a failed login attempt, improving the user experience when authentication fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->